### PR TITLE
Fix for else statements un-indenting too much

### DIFF
--- a/fish-mode.el
+++ b/fish-mode.el
@@ -36,7 +36,7 @@ unc\\(?:ed\\|save\\|tions?\\)\\)\\|h\\(?:elp\\|istory\\)\\|i\\(?:f\\|satty\\)\\|
         (save-excursion
           (while not-indented
             (forward-line -1)
-            (if (looking-at "^[ \t]*\\(end\\|else\\)")
+            (if (looking-at "^[ \t]*\\(end\\)")
                 (progn
                   (forward-line -1)
                   (setq cur-indent (- (current-indentation) tab-width))


### PR DESCRIPTION
Small fix to avoid emacs moving back too far with an else statement

I was seeing the following

```
if x
    blah blah
else
blah blah
end
```

The else statement was not acting like an if and automatically indenting the next lines.
