### PR TITLE
Make switch a keyword not a builtin

### DIFF
--- a/fish-mode.el
+++ b/fish-mode.el
@@ -90,7 +90,6 @@
 	    "set_color"
 	    "source"
 	    "status"
-	    "switch"
 	    "test"
 	    "trap"
 	    "type"
@@ -117,6 +116,7 @@
 	    "if"
 	    "return"
 	    "set"
+	    "switch"
 	    "while"
 	    )
 	   symbol-end)


### PR DESCRIPTION
Oops, I had `switch` as a keyword instead of a builtin, so it was the wrong color.