### PR TITLE
Load fish-mode for `funced` files.

### DIFF
--- a/fish-mode.el
+++ b/fish-mode.el
@@ -443,6 +443,8 @@ For example, (fold F X '(1 2 3)) computes (F (F (F X 1) 2) 3)."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.fish\\'" . fish-mode))
 ;;;###autoload
+(add-to-list 'auto-mode-alist '("/fish_funced\\..*\\'" . fish-mode))
+;;;###autoload
 (add-to-list 'interpreter-mode-alist '("fish" . fish-mode))
 
 (provide 'fish-mode)


### PR DESCRIPTION
`funced` creates and edits files in `/tmp/fish_funced.<random string>`, which are not covered by existing entries in `auto-mode-alist` or others. Add an entry to `auto-mode-alist` that should find `fish_funced` files, in `/tmp` or elsewhere.