### PR TITLE
Highlight "and", "or", and "eval" as keywords

### DIFF
--- a/fish-mode.el
+++ b/fish-mode.el
@@ -44,7 +44,6 @@
    `( ,(rx symbol-start
 	   (or
 	    "alias"
-	    "and"
 	    "bg"
 	    "bind"
 	    "block"
@@ -60,7 +59,6 @@
 	    "dirs"
 	    "echo"
 	    "emit"
-	    "eval"
 	    "exec"
 	    "fg"
 	    "fish_config"
@@ -82,7 +80,6 @@
 	    "mimedb"
 	    "nextd"
 	    "open"
-	    "or"
 	    "popd"
 	    "prevd"
 	    "psub"
@@ -107,16 +104,19 @@
    ;; Keywords
    `( ,(rx symbol-start
 	   (or
+            "and"
 	    "begin"
 	    "break"
 	    "case"
 	    "continue"
 	    "else"
 	    "end"
+            "eval"
 	    "exit"
 	    "for"
 	    "function"
 	    "if"
+            "or"
 	    "return"
 	    "set"
 	    "switch"
@@ -125,7 +125,6 @@
 	   symbol-end)
       .
       font-lock-keyword-face)
-
 
    ;; Function name
    `( ,(rx symbol-start "function"


### PR DESCRIPTION
Since "and/or" control flow, they are more like keywords than
builtins, and more important, so they should be highlighted the same as
"if/else/end".

Also, "eval" is much more significant than a builtin like "echo", so
highlight it as a keyword.