### PR TITLE
auto load fish mode for the file fish_variables

### DIFF
--- a/fish-mode.el
+++ b/fish-mode.el
@@ -705,6 +705,8 @@ POSITIVE-RE and NEGATIVE-RE are regular expressions."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("/fish_funced\\..*\\'" . fish-mode))
 ;;;###autoload
+(add-to-list 'auto-mode-alist '("/fish_variables$" . fish-mode))
+;;;###autoload
 (add-to-list 'interpreter-mode-alist '("fish" . fish-mode))
 
 (provide 'fish-mode)


### PR DESCRIPTION
Hi,

This is a simple PR for automatically loading `fish-mode` for the file `fish_variables`.

https://stackoverflow.com/questions/20103968/where-are-universal-variables-stored-in-the-fish-shell

Can you take a look and merge if it is useful?

Thanks!